### PR TITLE
Remove value of -a  option when calling EMBLmyGFF3

### DIFF
--- a/RATTwithGFF.py
+++ b/RATTwithGFF.py
@@ -193,7 +193,7 @@ def gffsToEmbls(contigNames):
                             "-x", "UNC",\
                             "--rg","none",\
                             "-r","1",\
-                            "-a",contig,\
+                            "-a",\
                             "--keep_duplicates",\
                             "-q",\
                             "--shame"])


### PR DESCRIPTION
-a option is a bolean, no need to use a value. It can be problematic.
Fix #3 
Fix #4 